### PR TITLE
Add indikator mutu form

### DIFF
--- a/__test__/IndicatorMutuForm.test.tsx
+++ b/__test__/IndicatorMutuForm.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import IndicatorMutuForm from '@/components/organisms/IndicatorMutuForm/IndicatorMutuForm'
+import '@testing-library/jest-dom'
+
+describe('IndicatorMutuForm', () => {
+  it('renders form fields', () => {
+    render(<IndicatorMutuForm />)
+    expect(screen.getByLabelText(/Nama Indikator/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Deskripsi/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Target/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Verifikator/i)).toBeInTheDocument()
+  })
+})

--- a/app/indikator-mutu/page.tsx
+++ b/app/indikator-mutu/page.tsx
@@ -1,0 +1,10 @@
+import IndicatorMutuForm from '@/components/organisms/IndicatorMutuForm/IndicatorMutuForm'
+
+export default function IndikatorMutuPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-lg font-bold mb-4">Input Indikator Mutu</h1>
+      <IndicatorMutuForm />
+    </div>
+  )
+}

--- a/components/organisms/IndicatorMutuForm/IndicatorMutuForm.tsx
+++ b/components/organisms/IndicatorMutuForm/IndicatorMutuForm.tsx
@@ -1,0 +1,69 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+
+export interface IndicatorMutuFormValues {
+  nama: string
+  deskripsi: string
+  target: number
+  verifikator: string
+}
+
+export default function IndicatorMutuForm() {
+  const { register, handleSubmit, reset } = useForm<IndicatorMutuFormValues>()
+
+  const onSubmit = (data: IndicatorMutuFormValues) => {
+    console.log('Indikator Mutu:', data)
+    reset()
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium" htmlFor="nama">
+          Nama Indikator
+        </label>
+        <input
+          id="nama"
+          {...register('nama', { required: true })}
+          className="border p-2 mt-1 w-full rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium" htmlFor="deskripsi">
+          Deskripsi
+        </label>
+        <textarea
+          id="deskripsi"
+          {...register('deskripsi')}
+          className="border p-2 mt-1 w-full rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium" htmlFor="target">
+          Target
+        </label>
+        <input
+          id="target"
+          type="number"
+          {...register('target', { required: true, valueAsNumber: true })}
+          className="border p-2 mt-1 w-full rounded-md"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium" htmlFor="verifikator">
+          Verifikator
+        </label>
+        <select
+          id="verifikator"
+          {...register('verifikator')}
+          className="border p-2 mt-1 w-full rounded-md"
+        >
+          <option value="Komite">Komite</option>
+          <option value="Verifikator">Verifikator</option>
+        </select>
+      </div>
+      <Button type="submit">Simpan</Button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- add an IndicatorMutuForm component with simple fields and a submit handler
- expose new page at `/indikator-mutu` that shows the form
- test IndicatorMutuForm rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c8f6edff0832bb5bd967e346816d6